### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -29,7 +29,7 @@ Our SDK allows you to select which features and functionality you need as well a
 - [Push Notifications](https://github.com/printdotio/printio-ios-sdk/blob/master/docs/Reference/PUSH_NOTIFICATIONS.md) the PrintIO SDK also offers the ability to send push notifications from your app.
 - [Social Media Account Setup] (https://github.com/printdotio/printio-ios-sdk/blob/master/docs/Reference/SocialMediaAccountSetup.md) the PrintIO SDK allows you to change to your social media accounts. Use this guide if you have questions regarding what information and settings are needed.
 
-### iOS 9 and XCode 7 support:
+### iOS 9 and Xcode 7 support:
 - To avoid waring "The resource could not be loaded because the App Transport Security policy requires the use of a secure connection." please add next lines to info.plist (temporary solution):
 ```Objective-C
 <key>NSAppTransportSecurity</key>


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
